### PR TITLE
Fix for no restaurants return + remove unused invalidAdress action

### DIFF
--- a/src/Component/RestaurantWheel/RestaurantWheel.js
+++ b/src/Component/RestaurantWheel/RestaurantWheel.js
@@ -7,10 +7,10 @@ export default ({
   address,
   fetchError,
   handleAddressChange,
-  invalidAddress,
   loading,
   restaurantShown,
   submitForm,
+  noRestaurants,
 }) =>
   <section
     className={`${restaurantShown ? 'is-hidden' : ''}`}
@@ -24,14 +24,11 @@ export default ({
         <div className="control">
           <label className="label">
             Adresse
-            {invalidAddress &&
-              <span className="error">Cette adresse est introuvable :(</span>
-            }
           </label>
           <input
             type="text"
             name="address"
-            className={`input address ${invalidAddress ? 'error' : ''}`}
+            className="input address"
             onChange={handleAddressChange}
             value={address}
           />
@@ -40,6 +37,7 @@ export default ({
       <RestaurantFilters/>
 
       {fetchError && <span className="global-error">Une erreur est survenue :(</span>}
+      {noRestaurants && <span className="global-error">Aucun restaurants à proposer :(</span>}
 
       <button
         className={`submit-address ${address.length > 3 ? 'ready' : ''} button ${loading ? 'is-loading' : ''}`}

--- a/src/Component/RestaurantWheel/index.js
+++ b/src/Component/RestaurantWheel/index.js
@@ -10,9 +10,9 @@ import { compose, path, pipe, tap } from 'ramda'
 const mapStateToProps = state => ({
   address: state.RestaurantWheel.address,
   fetchError: state.RestaurantWheel.fetchError,
-  invalidAddress: state.RestaurantWheel.invalidAddress,
   loading: state.RestaurantWheel.loading,
   restaurantShown: state.RestaurantWheel.restaurantShown,
+  noRestaurants: state.RestaurantWheel.noRestaurants,
 })
 
 // mapDispatchToProps :: (Action * -> State) -> Props

--- a/src/Epic/RestaurantWheel.js
+++ b/src/Epic/RestaurantWheel.js
@@ -6,6 +6,8 @@ import {
 } from './../Util'
 import {
   defaultTo,
+  ifElse,
+  isEmpty,
   join,
   prop,
   pipe,
@@ -20,6 +22,7 @@ import {
   RESTAURANT_DETAILS_RECEIVED,
   RESTAURANT_RECEIVED,
   fetchError,
+  noRestaurants,
   restaurantDetailsReceived,
   restaurantReceived,
   showRestaurant,
@@ -43,9 +46,15 @@ export const getRestaurantEpic = (action$, state$, { fetchApi }) =>
     )),
     map(pipe(
       defaultTo([]),
-      getRandomElementFromArray,
-      prop('id'),
-      restaurantReceived,
+      ifElse(
+        isEmpty, 
+        noRestaurants,
+        pipe(
+          getRandomElementFromArray,
+          prop('id'),
+          restaurantReceived,
+        ), 
+      )
     )),
     logObservableErrorAndTriggerAction(fetchError),
   )

--- a/src/Epic/RestaurantWheel.spec.js
+++ b/src/Epic/RestaurantWheel.spec.js
@@ -46,6 +46,32 @@ describe('Epic :: RestaurantWheel :: getRestaurantEpic', () => {
       })
       .catch(error => {fail(error); done()})
   }, 1000)
+
+  it('dispatches NO_RESTAURANTS action', done => {
+    const action$ = ActionsObservable.of(reducer.getRestaurant())
+    const state$ = createStateObservable({
+      RestaurantWheel: {
+        address: 'Nowhere'
+      },
+      RestaurantFilters: {
+        cuisineTypes: [],
+        diets: [],
+        prices: [],
+      }
+    })
+    const fetchApiUrl = []
+    const deps = {
+      fetchApi: createFetchApiMock([], fetchApiUrl)
+    }
+
+    epic.getRestaurantEpic(action$, state$, deps)
+      .toPromise(Promise)
+      .then(action => {
+        expect(action.type).toEqual(reducer.NO_RESTAURANTS)
+        done()
+      })
+      .catch(error => {fail(error); done()})
+  }, 1000)
 })
 
 describe('Epic :: RestaurantWheel :: getRestaurantDetailsEpic', () => {

--- a/src/Redux/State/RestaurantWheel.js
+++ b/src/Redux/State/RestaurantWheel.js
@@ -8,7 +8,7 @@ export const INITIAL_STATE = {
   restaurant: null,
   restaurantShown: false,
   fetchError: false,
-  invalidAddress: false,
+  noRestaurants: false,
 }
 
 // action types
@@ -19,7 +19,7 @@ export const RESTAURANT_DETAILS_RECEIVED = '@knp-keskonmang/RestaurantWheel/REST
 export const SHOW_RESTAURANT = '@knp-keskonmang/RestaurantWheel/SHOW_RESTAURANT'
 export const BACK_TO_SEARCH = '@knp-keskonmang/RestaurantWheel/BACK_TO_SEARCH'
 export const FETCH_ERROR = '@knp-keskonmang/RestaurantWheel/FETCH_ERROR'
-export const INVALID_ADDRESS = '@knp-keskonmang/RestaurantWheel/INVALID_ADDRESS'
+export const NO_RESTAURANTS = '@knp-keskonmang/RestaurantWheel/NO_RESTAURANTS'
 
 // handleAddress :: String -> Action
 export const handleAddress = address => ({
@@ -51,21 +51,21 @@ export const backToSearch = always({ type: BACK_TO_SEARCH })
 // fetchError :: () -> Action
 export const fetchError = always({ type: FETCH_ERROR })
 
-// invalidAddress :: () -> Action
-export const invalidAddress = always({ type: INVALID_ADDRESS })
+// noRestaurants :: () -> Action
+export const noRestaurants = always({ type: NO_RESTAURANTS })
 
 // Session :: (State, Action *) -> State
 export default createReducer(INITIAL_STATE, {
   [HANDLE_ADDRESS]: (state, { address }) => ({
     ...state,
     address: address,
-    invalidAddress: false,
   }),
 
   [GET_RESTAURANT]: state => ({
     ...state,
     loading: true,
     fetchError: false,
+    noRestaurants: false,
   }),
 
   [RESTAURANT_DETAILS_RECEIVED]: (state, { restaurant }) => ({
@@ -90,8 +90,9 @@ export default createReducer(INITIAL_STATE, {
     loading: false,
   }),
 
-  [INVALID_ADDRESS]: state => ({
+  [NO_RESTAURANTS]: state => ({
     ...state,
-    invalidAddress: true,
+    loading: false,
+    noRestaurants: true,
   }),
 })

--- a/src/Redux/State/RestaurantWheel.spec.js
+++ b/src/Redux/State/RestaurantWheel.spec.js
@@ -5,7 +5,7 @@ import {
   fetchError,
   getRestaurant,
   handleAddress,
-  invalidAddress,
+  noRestaurants,
   restaurantDetailsReceived,
   showRestaurant,
 } from './RestaurantWheel'
@@ -16,17 +16,11 @@ describe('Redux :: State :: RestaurantWheel', () => {
   })
 
   it('reduces handleAddress action', () => {
-    const s1 = {
-      ...INITIAL_STATE,
-      invalidAddress: true,
-    }
-
     expect(
-      reducer(s1, handleAddress('11, rue Kervegan'))
+      reducer(INITIAL_STATE, handleAddress('11, rue Kervegan'))
     ).toEqual({
-      ...s1,
+      ...INITIAL_STATE,
       address: '11, rue Kervegan',
-      invalidAddress: false,
     })
   })
 
@@ -100,12 +94,12 @@ describe('Redux :: State :: RestaurantWheel', () => {
     })
   })
 
-  it('reduces invalidAddress action', () => {
+  it('reduces noRestaurants action', () => {
     expect(
-      reducer(INITIAL_STATE, invalidAddress())
+      reducer(INITIAL_STATE, noRestaurants())
     ).toEqual({
       ...INITIAL_STATE,
-      invalidAddress: true,
+      noRestaurants: true,
     })
   })
 })


### PR DESCRIPTION
- If no restaurants were return, so the loader never stopped to loop and no message to inform
- The "invalidAddress" action was useful when we used Foursquare when we had to generate geographical coordinates from a given address, but useless now

https://trello.com/c/4p2SBCaC/55-bug-g%C3%A9rer-le-cas-o%C3%B9-aucun-restaurant-nest-retourn%C3%A9