### PR TITLE
Fix design

### DIFF
--- a/src/Component/Logo/Logo.js
+++ b/src/Component/Logo/Logo.js
@@ -6,7 +6,7 @@ const FullWidthLogo = () =>
   <img
     src="/images/logo-keskonmang.svg"
     alt="logo"
-    className="is-hidden-touch"
+    className="full is-hidden-touch"
   />
 
 // HorizontalLogo :: Props -> React.Component
@@ -14,7 +14,7 @@ const HorizontalLogo = ({ className = '' }) =>
   <img
     src="/images/keskonmang-horizontal-01.svg"
     alt="logo"
-    className={className}
+    className={ `horizontal ${className}` }
   />
 
 // Logo :: Props -> React.Component

--- a/src/Component/Logo/Logo.sass
+++ b/src/Component/Logo/Logo.sass
@@ -3,9 +3,16 @@
 figure[data-is="brand-logo"]
     padding: $size-5
     margin-top: $size-5
-    width: 350px
+    width: 70%
+    max-height: 350px
+    text-align: center
     cursor: pointer
 
+    img.full
+        max-height: calc(350px - 40px)
+
+    img.horizontal
+        max-width: 600px
+
     @media(max-width: $size-tablet)
-        margin: 0
-        width: 250px
+        width: 90%

--- a/src/Component/RestaurantDetails/RestaurantDetails.js
+++ b/src/Component/RestaurantDetails/RestaurantDetails.js
@@ -17,71 +17,68 @@ export default ({
   getRestaurant,
   backToSearch,
   restaurantShown,
-}) =>
-  restaurantShown &&
-  <div className="details-container">
-    <section data-is="restaurant-details">
-      <figure className="restaurant-image">
-        {restaurant.url &&
-          <a
-            href={restaurant.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="website"
-          >
-            <img
-              src="/images/circle_right.svg"
-              alt="Voir la fiche sur Yelp"
-              title="Voir la fiche sur Yelp"
-            />
-          </a>
-        }
-        {restaurant.image_url
-          ? <img src={restaurant.image_url} alt={restaurant.name} />
-          : <img className="placeholder" src={placeholderImages[Math.floor(Math.random() * 6)]} alt="Keskonmang'" />
-        }
-      </figure>
+}) => restaurantShown &&
+  <section data-is="restaurant-details">
+    <figure className="restaurant-image">
+      {restaurant.url &&
+        <a
+          href={restaurant.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="website"
+        >
+          <img
+            src="/images/circle_right.svg"
+            alt="Voir la fiche sur Yelp"
+            title="Voir la fiche sur Yelp"
+          />
+        </a>
+      }
+      {restaurant.image_url
+        ? <img src={restaurant.image_url} alt={restaurant.name} />
+        : <img className="placeholder" src={placeholderImages[Math.floor(Math.random() * 6)]} alt="Keskonmang'" />
+      }
+    </figure>
 
-      <h1 className="title">{restaurant.name}</h1>
-      <div className="separator"> </div>
+    <h1 className="title">{restaurant.name}</h1>
+    <div className="separator"> </div>
 
-      <p className="address">
-        {restaurant.location.address1} {restaurant.location.address2 && !restaurant.location.address3 && 
-          <span>({restaurant.location.address2})</span>
-        } {restaurant.location.address2 && restaurant.location.address3 && 
-          <span>({restaurant.location.address2} - {restaurant.location.address13})</span>
-        }
-        <br />
-        {restaurant.location.zip_code} {restaurant.location.city}, {restaurant.location.country}
+    <p className="address">
+      {restaurant.location.address1} {restaurant.location.address2 && !restaurant.location.address3 && 
+        <span>({restaurant.location.address2})</span>
+      } {restaurant.location.address2 && restaurant.location.address3 && 
+        <span>({restaurant.location.address2} - {restaurant.location.address13})</span>
+      }
+      <br />
+      {restaurant.location.zip_code} {restaurant.location.city}, {restaurant.location.country}
+    </p>
+
+    {restaurant.display_phone &&
+      <p className="phone">
+        <a href="tel:{restaurant.display_phone}">{restaurant.display_phone}</a>
       </p>
+    }
 
-      {restaurant.display_phone &&
-        <p className="phone">
-          <a href="tel:{restaurant.display_phone}">{restaurant.display_phone}</a>
-        </p>
-      }
-
-      {restaurant.price &&
-        <div className={`price price-${restaurant.price.length}`}>
-          <p>Prix :</p>
-          <span className="bullet"> </span>
-          <span className="bullet"> </span>
-          <span className="bullet"> </span>
-          <span className="bullet"> </span>
-        </div>
-      }
-      <button
-        className={`next-restaurant button ${loading ? 'is-loading' : ''}`}
-        onClick={getRestaurant}
-      >
-        <img
-          className={`${loading ? 'is-hidden': ''}`}
-          src="/images/retry.svg"
-          alt="Retry icon"
-        />
-        Chercher à nouveau
-      </button>
-    </section>
+    {restaurant.price &&
+      <div className={`price price-${restaurant.price.length}`}>
+        <p>Prix :</p>
+        <span className="bullet"> </span>
+        <span className="bullet"> </span>
+        <span className="bullet"> </span>
+        <span className="bullet"> </span>
+      </div>
+    }
+    <button
+      className={`next-restaurant button ${loading ? 'is-loading' : ''}`}
+      onClick={getRestaurant}
+    >
+      <img
+        className={`${loading ? 'is-hidden': ''}`}
+        src="/images/retry.svg"
+        alt="Retry icon"
+      />
+      Chercher à nouveau
+    </button>
 
     <button className="back-button" onClick={backToSearch}>Changer ma recherche</button>
-  </div>
+  </section>

--- a/src/Component/RestaurantDetails/RestaurantDetails.sass
+++ b/src/Component/RestaurantDetails/RestaurantDetails.sass
@@ -1,17 +1,11 @@
 @import '../../Style/Variables.sass';
 @import '../../Style/Mixins.sass';
 
-.details-container
-    position: relative
-
-    @media(max-width: $size-tablet)
-        width: 100%
-
 section[data-is="restaurant-details"]
     width: 600px
     padding: $size-4
-    padding-bottom: $size-1
-    margin-top: 20px
+    padding-bottom: $size-3
+    margin-bottom: 90px
     border-radius: $size-5
     text-align: center
     background: white
@@ -21,7 +15,7 @@ section[data-is="restaurant-details"]
         overflow: hidden
         position: relative
         height: 240px
-        margin-bottom: $size-3
+        margin-bottom: $size-6
 
         img
             width: 100%
@@ -55,14 +49,13 @@ section[data-is="restaurant-details"]
         width: $size-3
         height: 3px
         background: #ff5a5e
-        margin: 0 auto $size-4 auto
+        margin: 0 auto $size-6 auto
         border-radius: 3px
 
     p
       margin: $size-7
 
     p.address, p.phone
-        margin: 0
         font-size: $size-6
 
     div.price
@@ -123,6 +116,19 @@ section[data-is="restaurant-details"]
         &:hover
             background: $green-hover
 
+    button.back-button
+        position: absolute
+        left: 0
+        right: 0
+        bottom: -80px
+        margin: auto
+        font-size: $size-5
+        text-decoration: underline
+        border: none
+        background: none
+        color: white
+        cursor: pointer
+
     @media(max-width: $size-tablet)
         padding: $size-6
         margin-top: 0
@@ -133,7 +139,7 @@ section[data-is="restaurant-details"]
             margin-bottom: $size-5
 
         figure.restaurant-image
-            height: 80px
+            height: 150px
             margin-bottom: $size-6
 
         .separator
@@ -153,16 +159,3 @@ section[data-is="restaurant-details"]
                 height: 25px
                 width: 25px
                 left: 10px
-
-button.back-button
-    position: absolute
-    left: 0
-    right: 0
-    bottom: -80px
-    margin: auto
-    font-size: $size-5
-    text-decoration: underline
-    border: none
-    background: none
-    color: white
-    cursor: pointer

--- a/src/Component/RestaurantFilters/RestaurantFilters.js
+++ b/src/Component/RestaurantFilters/RestaurantFilters.js
@@ -29,7 +29,7 @@ export default ({
   dietFiltersLoaded,
   priceFiltersLoaded,
 }) => 
-  <div>
+  <div className="filters">
     <div className="field filter">
       <div className="control">
         <label className="label">Type de cuisine</label>

--- a/src/Component/RestaurantFilters/RestaurantFilters.sass
+++ b/src/Component/RestaurantFilters/RestaurantFilters.sass
@@ -1,23 +1,31 @@
 @import '../../Style/Variables.sass';
 
-.filter
-    width: 39%
-    margin-right: 1%
-    display: inline-block
+.filters
+    .filter
+        width: 39%
+        margin-right: 1%
+        display: inline-block
 
-    &:nth-child(3)
-        width: 20%
-        margin: 0
-
-    .tags-input 
-        border-color: $lightPink
-        .tag.is-rounded
-            z-index: 1
-            border-radius: 0.75rem
-        .input
-            position: absolute
-            top: 0
-            bottom: 0
-            left: 0
-            right: 0
+        &:nth-child(3)
+            width: 20%
             margin: 0
+
+        .tags-input 
+            border-color: $lightPink
+            .tag.is-rounded
+                z-index: 1
+                border-radius: 0.75rem
+            .input
+                position: absolute
+                top: 0
+                bottom: 0
+                left: 0
+                right: 0
+                margin: 0
+
+    @media(max-width: $size-tablet)
+        margin-bottom: 30px
+
+        .filter,
+        .filter:nth-child(3)
+            width: 100%

--- a/src/Component/RestaurantWheel/RestaurantWheel.sass
+++ b/src/Component/RestaurantWheel/RestaurantWheel.sass
@@ -6,7 +6,7 @@ section[data-is="restaurant-wheel"]
     border-radius: $size-5
     text-align: center
     background: white
-    margin: 80px 0 30px 0
+    margin: 30px 0 60px 0
     position: relative
 
     h1.title
@@ -89,7 +89,3 @@ section[data-is="restaurant-wheel"]
             button.submit-address
                 font-size: $size-5
                 bottom: -25px
-
-            .filter,
-            .filter:nth-child(4)
-                width: 100%

--- a/src/Style/App.sass
+++ b/src/Style/App.sass
@@ -20,7 +20,7 @@ body
     background: linear-gradient(180deg, rgba(255,90,94,1) 0%, rgba(252,126,96,1) 100%)
     background-attachment: fixed
     font-family: $regularFont
-    height: 100%
+    min-height: 100%
 
     .main-container
         display: flex


### PR DESCRIPTION
- `height:100%` on the body refers to the window size, not to the actual page content size. So when filter options add scroll on page, the body background doesn't expand til the bottom. But it need to have a `min-height` when there is no filter options and no elements touch the bottom window.
- Modify margin on the section with the form, because of filters, to improve its position.
- Fix filters/submit button on mobile view
- Fix logo size on different screen size
- Remove useless div wrapper on restaurant details page